### PR TITLE
Disable CTU-SME test under TSAN

### DIFF
--- a/tests/ctu-sme-11-vm-win7ad.zeek
+++ b/tests/ctu-sme-11-vm-win7ad.zeek
@@ -2,6 +2,10 @@
 # message.
 # @TEST-REQUIRES: ! grep -q "#define ENABLE_SPICY_SSL" $BUILD/zeek-config.h
 
+# Running this test under the thread sanitizer either takes a very long time to complete (on the
+# order of hours) or segfaults. Disable for the time being in that environment.
+# @TEST-REQUIRES: ! grep -q "#define ZEEK_TSAN" $BUILD/zeek-config.h
+
 # @TEST-REQUIRES: have-spicy
 # @TEST-EXEC: cat $TRACES/CTU-SME-11-Experiment-VM-Microsoft-Windows7AD-1-malicious-filtered.pcap.gz | gunzip | zeek -r - %INPUT
 # @TEST-EXEC: $SCRIPTS/diff-all '*.log'


### PR DESCRIPTION
See https://github.com/zeek/zeek/issues/4092 for details. This disables the test for the time being to keep master building until we can look at it.